### PR TITLE
Add STATICFILES_DIRS to collect root static folder

### DIFF
--- a/webAppProject/settings.py
+++ b/webAppProject/settings.py
@@ -134,6 +134,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 
@@ -141,3 +142,4 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+


### PR DESCRIPTION

This pull request makes a configuration update to the Django project's static files handling. The main change is the addition of the `STATICFILES_DIRS` setting, which specifies an extra directory for collecting static files.

**Static files configuration:**

* Added `STATICFILES_DIRS` to `settings.py` to include the `static` directory in the project's base directory for static files collection.